### PR TITLE
Various markdown format fixes

### DIFF
--- a/docs/Art/Style Guide/cat-sprites.md
+++ b/docs/Art/Style Guide/cat-sprites.md
@@ -121,6 +121,7 @@ When you draw out the shape of the patches, try to give them more depth by follo
 _by scribble (scribblecrumb)_
 
 Accessories (Accs) range from collars to leaves scattered through fur. We want to take care that any new accessories follow these guidelines:
+
 - Do not obscure a significant amount of the cat (at most 1/3 of the cat may be covered)
 - Accs should always be attached to the cat (exceptions allowed for younger age stages).  We don't want an acc to be a snail sitting next to the cat, for example.
 - Likewise, accs should generally avoid being a living animal.  There's some leeway here, with insects for instance.  But we don't want a mouse clinging to the cat or a snake winding around it's shoulders.

--- a/docs/Art/basic.md
+++ b/docs/Art/basic.md
@@ -52,6 +52,7 @@ Once you've finished your BG, you will need to provide separate .png files for e
 `[season]_camp#_[light/dark]`
 
 Seasons must be spelled and capitalized as following:
+
 - greenleaf
 - leaffall
 - leafbare

--- a/docs/Code/basic.md
+++ b/docs/Code/basic.md
@@ -13,6 +13,7 @@ This will cover the basic information for code.
 This form will be used to create bug reports in the repo in the future.
 
 **Type:** (only select one)
+
 * UI - anything to do with the user interface. Maybe a button is not working, or the way some assets are formatted seems to be off.
 * Sprite - an issue with the art in the game
 * Code - general bugs related to how the game runs and responds to you. 
@@ -22,6 +23,7 @@ This form will be used to create bug reports in the repo in the future.
 ex.: This bug implies that the cat is never ....
 
 **Grade:** (only select one)
+
 * Game-breaking - a bug that makes it impossible to play the game
 * Dire - Still playable, but a major feature is broken
 * Important - The bug has a large affect on the gameplay, but is not urgent
@@ -31,6 +33,7 @@ ex.: This bug implies that the cat is never ....
 
 **Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/docs/Code/content-adding.md
+++ b/docs/Code/content-adding.md
@@ -4,6 +4,7 @@
 To make the camp backgrounds themselves, go to [this page](https://github.com/ClanGenOfficial/clangen/wiki/%5BArt%5D-%E2%80%90-Basic#camp-bgs). Style guide for camp backgrounds can be found [here](https://github.com/ClanGenOfficial/clangen/wiki/%5BArt%5D-%E2%80%90-Style-Guides#camp-bgs-style-guide).
 
 The steps for adding a new camp background to the game go as following:
+
 1. **Add the camp image files to the correct folders with the correct names**
 2. **Creating and coding in a button to select said camp in clan creation screen**
 3. **Adjusting cat sprite & label placements inside the camp, if needed**

--- a/docs/Code/content-adding.md
+++ b/docs/Code/content-adding.md
@@ -141,6 +141,7 @@ Under the default are listed all camps, named in this format: `Biome+camp#`. You
 The editing process is quite straightforward and simple, although tedious; it involves a lot of testing to see what looks right. You edit the numbers after the "dens" to change the placements of the den labels. To edit the cat sprite placements, you edit the numbers in the lists after each "place". You are also able to add (or reduce) cat sprite placements by adding `[[number, number], "xy"]` in any of the lists - just be mindful of the right amount of square brackets and correct comma placements.
 
 Few numbers to keep in mind:
+
 - A single cat sprite on the camp screen counts for 100x100 pixels
 - Camp screen length is 1600 pixels. This means that to not have cat sprites go behind the screens, their x-coordinate should not be placed beyond 1500 pixels.
 - Camp screen height is 1400 pixels. Like before, the cat sprite y-coordinates shouldn't be placed beyond 1300 pixels.

--- a/docs/Project basics/development-team-roles.md
+++ b/docs/Project basics/development-team-roles.md
@@ -2,19 +2,19 @@
 
 ## Team Roles
 - **Beta Tester**
-  - _Players who help us test the dev version of the game and have been given access to beta tester discord channels after application acceptance._
+    - _Players who help us test the dev version of the game and have been given access to beta tester discord channels after application acceptance._
 - **Apprentice Developer**
-  - _Developers who have been added to the team via application acceptance, but have not yet contributed to the dev or base game._
+    - _Developers who have been added to the team via application acceptance, but have not yet contributed to the dev or base game._
 - **Developer**
-  - _Developers who have contributed to the dev or base game._
+    - _Developers who have contributed to the dev or base game._
 - **Senior Developer**
-  - _Developers who have contributed significantly and have the responsibility of reviewing and accepting pull requests._
+    - _Developers who have contributed significantly and have the responsibility of reviewing and accepting pull requests._
 
 ## Beta tester expectations
 
 ### Making a GitHub Issues bug report: 
 1. Search the forums and the [issues list](https://github.com/ClanGenOfficial/clangen/issues) for your bug. If a post already exists for that error, don't make a new one. Please comment on the currently-existing issue to let us know that you are experiencing the issue as well, with as many screenshots as you can. 
-   1. This is especially relevant for typos and spelling errors, which should all be collected under the same issue.
+    1. This is especially relevant for typos and spelling errors, which should all be collected under the same issue.
 
 2.  If a post for your bug doesn't already exist, make one! You'll see a "New Issue" button on Issues page. Enter a title that is clear, specific, and easily searchable. Add any additional information (such as images, instructions to replicate) in the body of the issue. 
 

--- a/docs/Project basics/development-team-roles.md
+++ b/docs/Project basics/development-team-roles.md
@@ -75,6 +75,7 @@ SOMETHING SOMETHING milestone organisation
 Senior developers are those with write access to the Clangen github. Nothing can be merged to Clangen without the approval of at least two senior developers.
 
 If a Pull Request is meant to fix an issue, please ensure the following: Check (or have the developer check) whether the bug affects the latest release branch, too. If it does:
+
 - Tell the developer to change the target branch of their Pull Request to the latest release branch. For example, release-0.10
 - Ensure that the Pull Request only contains the bugfixes. New features, pelts, sprites, [...] don't belong in a bugfix; there's some exceptions like the Halloween toggle, but usually we want to make sure that there's no gameplay difference between... let's say v0.10.0 and v0.10.5
 - You may review and approve as per usual; I'd ask you to refrain from making merges to the release branches though

--- a/docs/Project basics/getting-started-with-github-and-clangen.md
+++ b/docs/Project basics/getting-started-with-github-and-clangen.md
@@ -4,30 +4,21 @@
 
 1. Make a GitHub account.
 2. Set up GitHub Desktop.
-- Install Git. 
-> You can install git on windows using https://git-scm.com/download/win
-> You can check if you have git installed by entering the command git --version in terminal
-- Install GitHub Desktop.
-- Log into GitHub in GitHub Desktop.
-
-
-(Optional) Git may be set to sign your commits with your email. If you would like your email to remain anonymous, see [Setting your commit email address on GitHub](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) and [Configuring your global author information](https://docs.github.com/en/desktop/configuring-and-customizing-github-desktop/configuring-git-for-github-desktop)
-
+    - Install Git. 
+    > You can install git on windows using https://git-scm.com/download/win
+    > 
+    > You can check if you have git installed by entering the command git --version in terminal
+    - Install GitHub Desktop.
+    - Log into GitHub in GitHub Desktop.
+    - (Optional) Git may be set to sign your commits with your email. If you would like your email to remain anonymous, see [Setting your commit email address on GitHub](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) and [Configuring your global author information](https://docs.github.com/en/desktop/configuring-and-customizing-github-desktop/configuring-git-for-github-desktop)
 3. Download an IDE
-
-An IDE (Integrated Development Environment) is a code interpreter. These are programs that allow you to view, run, and edit code, they generally provide shortcuts and point out errors to help speed the process. Importantly, that have the code equivalent of Microsoft Word's spellchecker, and help you by highlighting errors. PyCharm or Virtual Studio Code (VSC) are common favorites among the developers of Clangen, but you aren't required to use a specific one. GitHub desktop will automatically try to open the game files within your IDE, and your IDE will also display things like merging conflicts in an easier to understand way.
-
+    - An IDE (Integrated Development Environment) is a code interpreter. These are programs that allow you to view, run, and edit code, they generally provide shortcuts and point out errors to help speed the process. Importantly, that have the code equivalent of Microsoft Word's spellchecker, and help you by highlighting errors. PyCharm or Virtual Studio Code (VSC) are common favorites among the developers of Clangen, but you aren't required to use a specific one. GitHub desktop will automatically try to open the game files within your IDE, and your IDE will also display things like merging conflicts in an easier to understand way.
 4. Create a fork of Clangen
-
-A fork is a new repository that is a copy of an existing repository. By making a fork, it becomes easier to sync your code with any changes from the main Clangen repository. Changing things on your fork will not affect the main Clangen repository in any way. In fact, unless you are a Senior Contributor, it is _impossible_ for you to accidentally commit to the main Clangen repository.
-
-You can create a fork from GitHub Desktop or github web browser or using the terminal. [Github's documentation for doing so is here.](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
-
+    - A fork is a new repository that is a copy of an existing repository. By making a fork, it becomes easier to sync your code with any changes from the main Clangen repository. Changing things on your fork will not affect the main Clangen repository in any way. In fact, unless you are a Senior Contributor, it is _impossible_ for you to accidentally commit to the main Clangen repository.
+    - You can create a fork from GitHub Desktop or github web browser or using the terminal. [Github's documentation for doing so is here.](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
 5. Create branches of your own and other people's forks
-
-A branch represents a lineage of changes. You should make a new branch to track the changes you make from the base game (the "remote"). You branch _from_ forks, either your own or someone else's. 
-
-[This is how you make a branch.](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)
+    - A branch represents a lineage of changes. You should make a new branch to track the changes you make from the base game (the "remote"). You branch _from_ forks, either your own or someone else's. 
+    - [This is how you make a branch.](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)
 
 When working on multiple projects(or if you already have made a personal fork of clangen), sometimes it is required to work on multiple forks and branches from different developers (we'll refer to them as "sister forks"). Unfortunately, there is no way to do this directly through github desktop, but there is a work around. Branching from someone else's fork lets you PR to their fork, rather than the main Clangen repository, which is very helpful for large milestone development.
 

--- a/docs/Project basics/getting-started-with-github-and-clangen.md
+++ b/docs/Project basics/getting-started-with-github-and-clangen.md
@@ -33,20 +33,19 @@ When working on multiple projects(or if you already have made a personal fork of
 
 You can add multiple "sister forks" upstream of your branches, to say have one branch for your mod, another for the Clangen development version, and another for a secret development project you're contributing to. In order to create branches that are a copy of a "sister fork", you need to add them as another "remote".  If you have your current fork cloned onto your computer, you should already have two remotes - "origin", which is your repository, and "upsteam", which is the repository that you forked (ie, the Clangen repository). Here is how to add a third (or more):
 
-(1) Make sure you have Git installed on your computer. Not just Github desktop. Github Desktop uses a version of git that you can't access via the command line. 
+1. Make sure you have Git installed on your computer. Not just Github desktop. Github Desktop uses a version of git that you can't access via the command line. 
 > You can install git on windows using https://git-scm.com/download/win
 > You can check if you have git installed by entering the command git --version in terminal
-(2) Open up the Windows command line (or the mac/Linux equivalent). Ensure that the current working directory is the folder where you cloned your Clangen fork. 
-(3) Run this command with the remote url you need for the specific new remote. Here, this example is the git url to add the Lifegen development version as an upstream remote:
+2. Open up the Windows command line (or the mac/Linux equivalent). Ensure that the current working directory is the folder where you cloned your Clangen fork. 
+3. Run this command with the remote url you need for the specific new remote. Here, this example is the git url to add the Lifegen development version as an upstream remote:
 ```py 
 git remote add Lifegen_dev https://github.com/sedgestripe/clangen.git
 ``` 
 You can find this url here on the github page for a fork:
 ![An image showing where to find the url for a github branch, under the code button](https://media.discordapp.net/attachments/1229932793191206913/1232500116875902987/github_explain.png?ex=6629aeae&is=66285d2e&hm=a7052baf529201613c9441bbeda71cbcaa4c64bcc1bf65b28bd4891af99d719a&=&format=webp&quality=lossless&width=2206&height=1036)
+<br> The "Lifegen_dev" bit of the above command names the new remote for your github desktop. Name your remotes informatively.
 
-The "Lifegen_dev" bit of the above command names the new remote for your github desktop. Name your remotes informatively.
-
-(4) Run git fetch --all to fetch all the info from the new remote. 
+4. Run git fetch --all to fetch all the info from the new remote. 
 
 Now, when you look at "Other Branches" in Github desktop (if you use Github Desktop), you should see Lifegen's branches listed alongside the "upstream" and "origin" branches.  You can now treat it just like the Clangen "upstream" branches, and create a copy. 
 

--- a/docs/Writing/advanced-documentation.md
+++ b/docs/Writing/advanced-documentation.md
@@ -1,8 +1,10 @@
 # Advanced documentation
 
-## TODO: success in depth
+!!! todo "TODO"
+    success in depth
 
-## TODO: hunting filtering in depth
+!!! todo "TODO"
+    hunting filtering in depth
 
 
 !!! tip

--- a/docs/Writing/advanced-documentation.md
+++ b/docs/Writing/advanced-documentation.md
@@ -11,6 +11,7 @@
 ## Success chance calculation:
 
 The success chance is roughly equivalent to the percentage chance of the patrol succeeding. However, this rate is modified by a number of different effects.
+
 * Having a cat with a win skill/trait will raise the success rate by a base of 10. If the win skill is a 2nd level skill (i.e. great hunter, very smart, great speaker, ect) then an additional 5 is added.  If the win skill is a 3rd level skill (i.e. fantastic hunter, extremely smart, ect) then an additional 10 is added.  So, an excellent fighter could boost the success rate by 20 in total.
 * Having a cat with a fail skill/trait will lower the success rate by 15
 From there, the success rate is modified by the number of cats in the patrol and their exp.  
@@ -18,8 +19,7 @@ From there, the success rate is modified by the number of cats in the patrol and
 To explain what that means to someone without coding knowledge:
 * (1 + 0.10 * len(self.patrol_cats)) << this is multiplying the number of cats on the patrol by .10 and then adding 1. 
 * self.patrol_total_experience / (len(self.patrol_cats) * gm_modifier * 2) << this is finding the average of the cats' EXP and then multiplying it by the game mode modifier (this helps determine the difficulty of the game mode) and then multiplying it again by 2.
-* The two numbers are then multiplied together and added to the success rate
-
+* The two numbers are then multiplied together and added to the success rate<br>
 Then, a random number is rolled between 0 and 120.  If that number is below the success rate, yay! The patrol succeeds! If it's higher, then the patrol fails.  
 * Success rates are capped at 90 when EXP is added, and then capped again at 115 when win skill/trait modifiers are added.  So that means, no matter what, there will always be a teeny tiny chance of failure even with the best possible combination of cats.  It also means that you should not give your patrol a success rate higher than 90, and, honestly, should try to avoid giving anything higher than 80.
 

--- a/docs/Writing/basic.md
+++ b/docs/Writing/basic.md
@@ -145,8 +145,8 @@ Try to use phrases from this list when you can instead of using "our" version of
 - Embrace this! Such wild additions to the game in the past include such favorites as including kea and elephant seals from New Zealand, wolverines from North America, wolves from Definitely Not England, and having swift, kit, and fennec foxes available to find in the desert! 
 - Some biomes may require further research in order to give them a diverse set of animals to encounter, such as wetlands and desert which are very different to the original warriors setting. So go wild finding cool animals from those biomes who you want to see in the game!
 - There are some restrictions here, however, such as:
-  - We use the European badger, not the American badger
-  - Red foxes are European red foxes, not North American. European red foxes are larger than North American
+    - We use the European badger, not the American badger
+    - Red foxes are European red foxes, not North American. European red foxes are larger than North American
 - We encourage you to include interactions with megafauna, but see the following section for specific guidelines!
 
 ### Megafauna 
@@ -162,8 +162,8 @@ Try to use phrases from this list when you can instead of using "our" version of
 - Please try and keep animals behaving in a way that is realistic to how they behave in real life. For example, while there are many fox patrols, unfortunately it isn't very realistic to have them befriend the cats (nor is it canonical, with Hollyleaf's fox kit trying to attack her even though she saved its life)
 - If you want to include fun biological facts, this is encouraged! For example, the various fox patrols all have different success likelihoods and have the text explain that particular fox species' size compared to a warrior, so swift foxes are less dangerous than red ones. 
 - For patrols: 
-  - Keep in mind that it's absolutely okay and encouraged to make certain animal encounters restricted to certain seasons, but that if it's possible to encounter an animal, it should be possible to encounter it with any size of patrol - i.e if introducing a dangerous predator, make sure it can still be encountered by single cat patrols, even if those patrols are very lethal and difficult.
-  - Keep in mind that the size of a patrol should have a major impact on how difficult things are to accomplish. For example, while any size of patrol can encounter the maned wolf in the plains biome, only a full 6 cat patrol can try to fight the maned wolf
+    - Keep in mind that it's absolutely okay and encouraged to make certain animal encounters restricted to certain seasons, but that if it's possible to encounter an animal, it should be possible to encounter it with any size of patrol - i.e if introducing a dangerous predator, make sure it can still be encountered by single cat patrols, even if those patrols are very lethal and difficult.
+    - Keep in mind that the size of a patrol should have a major impact on how difficult things are to accomplish. For example, while any size of patrol can encounter the maned wolf in the plains biome, only a full 6 cat patrol can try to fight the maned wolf
 - There is a difference between venom and poison, as stated by the lovely Zabe: venom is if it bites you and you die, while poison is if you bite it and you die! It won't really matter, but if you want to spruce up your writing!
 
 #### Animal Names:
@@ -182,22 +182,22 @@ Some animals have multiple names that can refer to them, we want to keep our wri
 - We use American spelling!
 - Keep it simple!  We do not include direct dialogue within our events and we try to keep the word count of each event low.  
 - The classics:
-  - you're vs your
-    - "Your" is always possessive, while “you’re” = “you are”. If you aren’t sure whether “you’re” should be used in a sentence, imagine the same sentence with “you are” in place of “you’re/your” and see if it still makes sense.
-  - than vs then
-    - "Than" is used to compare things. For instance "I like cake better than pie." On the other hand, "then" relates to time. 1. "First I brushed my teeth, then I went to work." 2. "If there are no apples left, then please go to the store and get some."
-  - to vs too vs two
-    - “Too” means “in addition”, “as well”, or "excessively". For example, “Bluestar had some prey too.” Or, "The elder was too old to hunt." Two is, of course, only referring to the number. NGL my method for remembering “to” is just “if too should not be used” LOL but it’s kind of a “directional” word if that makes sense. Shows the relationship between two words, the opposite of “from”.
-  - its vs it's
-    - “Its” is always possessive. "It’s" is an abbreviation for “it is”. Again, if you’re not sure, try imagining the same sentence with “it is” in place of “its/it’s”.
-  - their vs they’re vs there
-    - "Their" is possessive. “Their tail”, “their prey”, etc. “There” refers to a place. “They’re” is an abbreviation for “they are”.
-  - affect vs effect
-    - Less common, but always seems to trip people up. “Affect” is a verb. “The poison has affected them quite strongly.” “Effect” is a noun. “They felt the effects of the poison quite strongly.”
-  - cats vs cat’s vs cats’
-    - Plurals and possessives! Basically, English grammar conventions are hell. I will try to make it not too confusing with the word cat as an example noun. "Cat's" = single cat, possessive. "The cat's tail." "Cats" = plural, multiple cats, not possessive. "The cats gathered around the High Rock." Cats' = plural possessive. "The cats' nests were lined with fresh moss." 
-    - For singular words that end in S, add an apostrophe to make them possessive. For instance, "the crocus' petals". For a possessive plural of a word that ends in S, add "es" to the end, then apostrophe. Random example sentence: "The actresses' rooms were located across the hall."
-    - Basically, anytime there's a possessive, you want an apostrophe in there somewhere. If the word ends in S, plural or singular, the apostrophe goes at the end. If the singular form of the word ends in S and it's a plural possessive, add "es" at the end, then apostrophe.  The exception to this is “it’s’ and “its”, where “its” is the possessive form and has no apostrophe.
+    - you're vs your
+        - "Your" is always possessive, while “you’re” = “you are”. If you aren’t sure whether “you’re” should be used in a sentence, imagine the same sentence with “you are” in place of “you’re/your” and see if it still makes sense.
+    - than vs then
+        - "Than" is used to compare things. For instance "I like cake better than pie." On the other hand, "then" relates to time. 1. "First I brushed my teeth, then I went to work." 2. "If there are no apples left, then please go to the store and get some."
+    - to vs too vs two
+        - “Too” means “in addition”, “as well”, or "excessively". For example, “Bluestar had some prey too.” Or, "The elder was too old to hunt." Two is, of course, only referring to the number. NGL my method for remembering “to” is just “if too should not be used” LOL but it’s kind of a “directional” word if that makes sense. Shows the relationship between two words, the opposite of “from”.
+    - its vs it's
+        - “Its” is always possessive. "It’s" is an abbreviation for “it is”. Again, if you’re not sure, try imagining the same sentence with “it is” in place of “its/it’s”.
+    - their vs they’re vs there
+        - "Their" is possessive. “Their tail”, “their prey”, etc. “There” refers to a place. “They’re” is an abbreviation for “they are”.
+    - affect vs effect
+        - Less common, but always seems to trip people up. “Affect” is a verb. “The poison has affected them quite strongly.” “Effect” is a noun. “They felt the effects of the poison quite strongly.”
+    - cats vs cat’s vs cats’
+        - Plurals and possessives! Basically, English grammar conventions are hell. I will try to make it not too confusing with the word cat as an example noun. "Cat's" = single cat, possessive. "The cat's tail." "Cats" = plural, multiple cats, not possessive. "The cats gathered around the High Rock." Cats' = plural possessive. "The cats' nests were lined with fresh moss." 
+        - For singular words that end in S, add an apostrophe to make them possessive. For instance, "the crocus' petals". For a possessive plural of a word that ends in S, add "es" to the end, then apostrophe. Random example sentence: "The actresses' rooms were located across the hall."
+        - Basically, anytime there's a possessive, you want an apostrophe in there somewhere. If the word ends in S, plural or singular, the apostrophe goes at the end. If the singular form of the word ends in S and it's a plural possessive, add "es" at the end, then apostrophe.  The exception to this is “it’s’ and “its”, where “its” is the possessive form and has no apostrophe.
 - All Clangen game text should follow normal grammar rules for capitalizing the first letter of a sentence, and trying to avoid spelling or grammar typos. We all make typos, don't worry! But this is one of the ways beta testing your new content can help you!
 - If you are struggling with remembering or understanding a grammar rule, even one that isn't mentioned in the above list, feel free to contact zabe#1117 on Discord for one on one help. Either DM or ping in the writing contributor thread, please!
 - The only exception to the above rule is Thoughts! Thoughts should be structured in such a way that they read as a full sentence if the cat’s name is read at the beginning.  For example: “Thinks about their past mistakes.” is the correct grammar for a Thought, as you could imagine a name at the beginning of the sentence and it would be grammatically correct.  However, the sentence should still be capitalized normally.
@@ -208,10 +208,10 @@ Event and flavor text should always use Americanized spelling.
 - Advice for fixing typos: control + F and control + shift + F is your friend, and the computer is going to be able to scan the entire document to find every time you wrote “teh” instead of “the” much faster than you can. If you are trying to fix typos in game files in VSCode, you can also use the search tool (magnifying glass on the left sidebar) to find every instance of a specific typo across all files in the currently-open folder and rapidly find and replace. Very useful for patrols, which often have many different iterations of the same text across different files.
 - If a code abbreviation (such as o_c_n) needs an ‘a’ or ‘an’ to precede it, always use “a”.  We have code in place to dynamically adjust ‘a’ and ‘an’ depending on the word that replaces the abbreviation.
 - HTML tags for bolding and italicizing are usable. These tags are:
-  - `<i>` and `</i>` for italicizing
-  - `<b>` and `</b>` for bolding
+    - `<i>` and `</i>` for italicizing
+    - `<b>` and `</b>` for bolding
 - Keeping a change log: as a writer, people are going to be super excited to experience what you write! Make sure to keep a rough record of what that might be, i.e Tiri has no idea how many fox patrols she has added total, but does know how many species are added are in what biomes, so that when she made the PR to merge them into the game she could mention their existence in the changelog for that PR.
-  - An easy way to keep track of your additions is with your commit titles and descriptions.  Making commits whenever you reach a ‘milestone’ of sorts and then titling it appropriately will leave you with a nice list of commits to review for your later change log.  When I bugfix, for example, I tend to make a commit every time I fix a bug and then title that commit with a short description of the bug I fixed.
+    - An easy way to keep track of your additions is with your commit titles and descriptions.  Making commits whenever you reach a ‘milestone’ of sorts and then titling it appropriately will leave you with a nice list of commits to review for your later change log.  When I bugfix, for example, I tend to make a commit every time I fix a bug and then title that commit with a short description of the bug I fixed.
 
 
 ### Being Mindful of Disabilities
@@ -265,15 +265,15 @@ When in doubt, please ask for feedback! We have multiple disabled contributors o
 - json - a file type. We use these files to hold strings and other important game info.  Nearly all of the strings in the game are held in jsons. Some IDEs, like PyCharm or virtual studio code, are able to help you properly format and spot errors in jsons. I’d recommend using one of those IDEs to help streamline your process.
 
 - Github Terms 
-  - github desktop - An application that makes syncing, editing, and committing your code easier. This, along with an IDE, is highly recommended for anyone contributing to the Clangen game files.
-  - repository / repo - In many ways, you can think of a Git repository as a directory that stores all the files, folders, and content needed for Clangen. What it actually is, is the object database of the project, storing everything from the files themselves, to the versions of those files, commits, deletions, et cetera. Repositories are not limited by user, and can be shared and copied (see: fork).
-  - PR - a Pull Request (PR) is how you will merge your code into a repository. Pull requests ask the repo maintainers to review the commits made, and then, if acceptable, merge the changes upstream.
+    - github desktop - An application that makes syncing, editing, and committing your code easier. This, along with an IDE, is highly recommended for anyone contributing to the Clangen game files.
+    - repository / repo - In many ways, you can think of a Git repository as a directory that stores all the files, folders, and content needed for Clangen. What it actually is, is the object database of the project, storing everything from the files themselves, to the versions of those files, commits, deletions, et cetera. Repositories are not limited by user, and can be shared and copied (see: fork).
+    - PR - a Pull Request (PR) is how you will merge your code into a repository. Pull requests ask the repo maintainers to review the commits made, and then, if acceptable, merge the changes upstream.
 merge - Taking the changes from one branch and adding them into another (traditionally master) branch. These commits are usually first requested via pull request before being merged by a project maintainer.
-  - pull - A “pull” happens when adding the changes to the master branch. 
-  - push - Updates a remote branch with the commits made to the current branch. You are literally “pushing” your changes onto the remote.
-  - origin - The conventional name for the primary version of a repository.
-  - fork - a fork is a copy of a repository.  This fork is unique to your github account and allows you to make edits without changing the original repository. 
-  - branch - A version of the repository that diverges from the main working project. Branches can be a new version of a repository, experimental changes, or personal forks of a repository for users to alter and test changes.
+    - pull - A “pull” happens when adding the changes to the master branch. 
+    - push - Updates a remote branch with the commits made to the current branch. You are literally “pushing” your changes onto the remote.
+    - origin - The conventional name for the primary version of a repository.
+    - fork - a fork is a copy of a repository.  This fork is unique to your github account and allows you to make edits without changing the original repository. 
+    - branch - A version of the repository that diverges from the main working project. Branches can be a new version of a repository, experimental changes, or personal forks of a repository for users to alter and test changes.
 
 
 ## Pronoun Tags

--- a/docs/Writing/basic.md
+++ b/docs/Writing/basic.md
@@ -223,25 +223,33 @@ When writing events related to permanent conditions, we need to be very mindful 
 
 - The idea that a cat is closer to a kitten than an adult
 >EG: "crawling" for paralysed cats - this implies they are weaker and also implies they are kit-like. This then takes away the paralysed cat's perceived ability to decide for themself, even though it's accidental. 
+>
 >INSTEAD: use "clambering", "climbing", "stalking" - these allow a paralysed cat to give themselves agency. 
+>
 >EXCEPTIONS: "Dragged" can be used in an emotional usage, such as "Poppyheart... drags herself to her front paws, complaining about dawn patrol". 
 
 - The idea that a cat "isn't" effected by their disability
 >EG: "Wolfclaw... is proud that they can still work like the rest of the clan." This makes it seem like the cat is comparing themselves to the abled cats, and sets up standards where a disabled cat cannot show their disability. This eventually means you're implying it's somehow "lesser" to be disabled. It might make sense for an insecure cat, but be careful!
+>
 >INSTEAD: Allow the disability to effect them, and focus on their personal achievements rather than comparing them to other cats. 
+>
 >EXCEPTIONS: "Raspy lungs", "joint pain", "allergies", "persistent headaches", "constantly dizzy", "recurring shock" - you can reword these into being happy their disability isn't as harsh this moon. These disabilities all come in "waves", where you can have a few days where you aren't as affected, and a few days where you're effected lots. 
 
 - The idea that a disability is only negative
 >EG: Any thoughts that give the idea that they'd prefer to be dead, excessive sadness about being disabled, etc.
+>
 >INSTEAD: Balance the thoughts out! Give them good thoughts alongside the bad! 
 
 - The idea that disabled cats can't make their own choices
 >EG: Excessive thoughts that imply a cat asking for another's opinion. 
+>
 >INSTEAD: Balance out the thoughts. Treat it like any other cat!
+>
 >EXCEPTIONS: Personality basis - insecure/gloomy/charismatic cats are more likely to ask for other opinions on personal things. 
 
 - The idea that disability is inherently worse than being abled
 >EG: Thoughts that imply shame or inherent upset about being disabled, comparison to abled cats, etc.
+>
 >INSTEAD: Use benign embarrassment! Maybe a cat with lasting grief fell asleep during a ceremony, or a cat with partial hearing loss misheard a request and brought moss instead of a mole.
 
 When in doubt, please ask for feedback! We have multiple disabled contributors on the team and they've lended us their valuable perspectives time and time again.

--- a/docs/Writing/basic.md
+++ b/docs/Writing/basic.md
@@ -268,7 +268,7 @@ When in doubt, please ask for feedback! We have multiple disabled contributors o
     - github desktop - An application that makes syncing, editing, and committing your code easier. This, along with an IDE, is highly recommended for anyone contributing to the Clangen game files.
     - repository / repo - In many ways, you can think of a Git repository as a directory that stores all the files, folders, and content needed for Clangen. What it actually is, is the object database of the project, storing everything from the files themselves, to the versions of those files, commits, deletions, et cetera. Repositories are not limited by user, and can be shared and copied (see: fork).
     - PR - a Pull Request (PR) is how you will merge your code into a repository. Pull requests ask the repo maintainers to review the commits made, and then, if acceptable, merge the changes upstream.
-merge - Taking the changes from one branch and adding them into another (traditionally master) branch. These commits are usually first requested via pull request before being merged by a project maintainer.
+    - merge - Taking the changes from one branch and adding them into another (traditionally master) branch. These commits are usually first requested via pull request before being merged by a project maintainer.
     - pull - A “pull” happens when adding the changes to the master branch. 
     - push - Updates a remote branch with the commits made to the current branch. You are literally “pushing” your changes onto the remote.
     - origin - The conventional name for the primary version of a repository.

--- a/docs/Writing/basic.md
+++ b/docs/Writing/basic.md
@@ -112,6 +112,7 @@ All biomes are different from each other and this should be taken into account w
 **Do not capitalize, except when beginning a sentence.**
  
 Spell and hyphenate as:
+
 - newleaf 
 - greenleaf
 - leaf-fall
@@ -168,6 +169,7 @@ Try to use phrases from this list when you can instead of using "our" version of
 
 #### Animal Names:
 Some animals have multiple names that can refer to them, we want to keep our writing consistent by only using a single agreed upon name.  
+
 - Use cougar for mountain lions/cougars
 - Use crayfish for crayfish/crawdads/koura
 - Use deathjaws for alligators, crocodiles, and any other crocodylomorphs!

--- a/docs/Writing/basic.md
+++ b/docs/Writing/basic.md
@@ -424,6 +424,7 @@ You can use either the backstory pool name, or an individual backstory name.  Wh
 
 #### prophecy_list
 Use this for amorphous, dreamy concepts.
+
 | Sense group | Examples |
 |--|--|
 | sight | blood pooling on the ground<br>a bird's feather<br>a ghostly pair of eyes |
@@ -436,6 +437,7 @@ Use this for amorphous, dreamy concepts.
 
 #### omen_list
 Use this for more physical ideas: odd and meaningful but still grounded in reality.
+
 | Sense group | Examples |
 |--|--|
 | sight | a five-pointed leaf<br>a split acorn<br>a dew-covered spider's web |
@@ -448,6 +450,7 @@ Use this for more physical ideas: odd and meaningful but still grounded in reali
 
 #### clair_list
 Use this for amorphous, unclear things that already happened/could happen.
+
 | Sense group | Examples |
 |--|--|
 | sound | the rumble of many paws on the ground<br>a betrayal on the wind<br>distant wails of grief |

--- a/docs/Writing/leader-ceremonies.md
+++ b/docs/Writing/leader-ceremonies.md
@@ -4,13 +4,13 @@
 - If using dialogue quotes, put a `\` before the `"` to allow it to work within a json.
 - Event text should be 400 character max, with 250 characters preferred (these counts aren't strict, as pronoun tags do artificially inflate them)
 - We have two versions of ceremonies! The StarClan and the Dark Forest.  Which one is used is determined by where the Clan's dead guide is residing.  Focus on the SC ceremonies, as they'll be seen most often, but when possible try to create Dark Forest versions of your SC ceremonies.
-  - Dark Forest ceremonies are held in `lead_ceremony_df.json`
-  - StarClan ceremonies are held in `lead_ceremony_sc.json`
+    - Dark Forest ceremonies are held in `lead_ceremony_df.json`
+    - StarClan ceremonies are held in `lead_ceremony_sc.json`
 - Ceremonies are structured as:
-  1. Intro
-  2. 9 separate life events
-      - If 9 dead cats are not available, any excess lives are given by an `Unknown Blessing` event
-  3. Outro
+    1. Intro
+    2. 9 separate life events
+        - If 9 dead cats are not available, any excess lives are given by an `Unknown Blessing` event
+    3. Outro
 - Each life giving event must include a virtue that the life represents.  
 
 ### Replacement Text:

--- a/docs/Writing/leaders-den-events.md
+++ b/docs/Writing/leaders-den-events.md
@@ -37,14 +37,14 @@ These should be flavored as occurring during the Gathering and should specify as
 > The type of interaction.  Each level of relationship with other clans has a matching positive and negative interaction type.  They are as follows:
 
 - ally
-  - negative: "offend"
-  - positive: "praise"
+    - negative: "offend"
+    - positive: "praise"
 - neutral
-  - negative: "provoke"
-  - positive: "befriend"
+    - negative: "provoke"
+    - positive: "befriend"
 - hostile
-  - negative: "antagonize"
-  - positive: "appease"
+    - negative: "antagonize"
+    - positive: "appease"
 
 ***
 
@@ -139,13 +139,13 @@ These events are flavored as the Clan going out to deliberately interact with th
 #### interaction_type: str
 > The type of interaction this event corresponds to:
 - "hunt"
-  - the Clan attempts to hunt down and kill the Outsider
+    - the Clan attempts to hunt down and kill the Outsider
 - "drive"
-  - the Clan attempts to find and drive out the Outsider (mechanically, this makes the cat "invisible" to the player and prevents them from interacting with the Clan anymore)
+    - the Clan attempts to find and drive out the Outsider (mechanically, this makes the cat "invisible" to the player and prevents them from interacting with the Clan anymore)
 - "invite"
-  - the Clan attempts to find and invite the Outsider into the Clan
+    - the Clan attempts to find and invite the Outsider into the Clan
 - "search"
-  - LOST CATS ONLY, the Clan searches for a lost Clanmate
+    - LOST CATS ONLY, the Clan searches for a lost Clanmate
 
 ***
 

--- a/docs/Writing/leaders-den-events.md
+++ b/docs/Writing/leaders-den-events.md
@@ -138,6 +138,7 @@ These events are flavored as the Clan going out to deliberately interact with th
 
 #### interaction_type: str
 > The type of interaction this event corresponds to:
+
 - "hunt"
     - the Clan attempts to hunt down and kill the Outsider
 - "drive"

--- a/docs/Writing/patrols.md
+++ b/docs/Writing/patrols.md
@@ -938,6 +938,7 @@ What each parameter does, and what the options are for outcomes.
 
 Outsider reputation changes
 > Defaults:
+>
 > | Outcome type          | Change                  |
 > |-----------------------|-------------------------|
 > | Success               | 1                       |
@@ -963,6 +964,7 @@ Outsider reputation changes
 
 Other clan reputation changes
 > Defaults:
+>
 > | Outcome type          | Change                  |
 > |-----------------------|-------------------------|
 > | Success               | 2                       |

--- a/docs/Writing/patrols.md
+++ b/docs/Writing/patrols.md
@@ -113,6 +113,7 @@ What each parameter does, and what the options are for patrol.
 >patrol_id is a unique string used to identify the patrol. It does not affect patrol behavior, but it allows us to easily find patrols.
 
 > A patrol_id is formatted as following: `biome_type_enemy_seasondescription#`, enemy and season are optional (some patrols do not have a specific enemy or season), # is a number at the end of the descriptive section starting at 1 and incrementing up as you create new versions of that patrol. 
+>
 >- If you are making new_cat or other_clan patrols, please include if the patrol is hostile/neutral/welcoming or hostile/neutral/allies in the ID
 >- If the patrol is under some kind of constraint, like being skill locked or relationship locked, please indicate that in the ID 
 

--- a/docs/Writing/patrols.md
+++ b/docs/Writing/patrols.md
@@ -653,6 +653,7 @@ What each parameter does, and what the options are for outcomes.
 >
 >Default behavior: 
 >In 1 and 2 cat patrols, only p_l can be stat_cat.
+>
 >In 3+ cat patrols, p_l and r_c can't be stat_cat, but anyone else is eligible. 
 
 >To override default behavior:
@@ -924,8 +925,11 @@ What each parameter does, and what the options are for outcomes.
 
 #### outsider_rep
 > This parameter is used for **all** patrols that involve new_cats, loners, and rogues (regardless of if the new cat joins, or if the loner or rogue is even open to joining the clan). It changes the reputation the player Clan has among outsiders, those who don't belong to any Clan. 
+>
 > If the player Clan has a welcoming reputation (above 71), new_cat patrols tagged with the ["new_cat" tag](https://github.com/ClanGenOfficial/clangen/wiki/%5BWriting%5D-%E2%80%90-Patrols#tags-liststr) have a increased chance to appear, and will be generated from the resources/dicts/patrols/new_cat_welcoming.json. 
+>
 > If the player Clan has a neutral reputation (between 31 to 70), new_cat patrols have no increased or deceased chance to appear, and will be generated from the resources/dicts/patrols/new_cat.json.
+>
 > If the player Clan has a hostile reputation (from 1 to 30), new_cat patrols have a decreased chance to appear, and will be generated from the resources/dicts/patrols/new_cat_hostile.json.
 >
 > The exception to this is if the player Clan has less than 20 cats. If the player Clan is small, the chance to get a new_cat patrol is overridden and becomes equal to the chance of the welcoming reputation. However, the new_cat patrols that are generated with the small_clan chance will still be generated from the json that is appropriate to the Clan's reputation.
@@ -947,8 +951,11 @@ Outsider reputation changes
 
 #### other_clan_rep
 > This parameter is used for **all** patrols that involve the other Clans that border the player Clan. It changes the reputation the player Clan has among it neighbors. 
+>
 > If the player Clan is allied with the other_clan the reputation will be greater than 17. The other_clan patrols will be generated from the resources/dicts/patrols/other_clan_allies.json. 
+>
 > If the player Clan is neutral with the other_clan the reputation will be equal or greater than 7 and less than or equal to 17. The other_clan patrols will be generated from the resources/dicts/patrols/other_clan.json. 
+>
 > If the player Clan is hostile with the other_clan the reputation will be less than 7. The other_clan patrols will be generated from the resources/dicts/patrols/other_clan_hostile.json. 
 >
 > By default 3 to 5 other Clans are generated on Clan creations to neighbor the player Clan. Relationships with the other Clans are individual, the player Clan can get along with one Clan and hate another. Relationships can also be influenced by the temperament of the other Clan and of the player Clan (link to appropriate documentation WIP)

--- a/docs/Writing/shortevents.md
+++ b/docs/Writing/shortevents.md
@@ -96,6 +96,7 @@ Some death events are considered "mass death" events (aka "mass extinction").  T
 the event_id is a unique string used to identify the event. It does not affect event behavior, but it allows us to easily find events.
 
 > An event_id is formatted as following: `biome_type_cause_seasondescription#`, 
+>
 >- 'cause' is something of a secondary type indicator.  Perhaps a death event is for death by heat stroke, you could use `heat` for the 'cause' section of the id. Or if a cat is hurt by a certain animal, you can indicate the animal here. If you cannot think of an appropriate 'cause' then you do not have to include one.
 >- if an event happens in more than one season, but not all seasons, then you can use `multi` for the 'season' section of the id
 >- If you are making new_cat or other_clan events, please include if the event is hostile/neutral/welcoming or hostile/neutral/allies in the ID

--- a/docs/Writing/thoughts.md
+++ b/docs/Writing/thoughts.md
@@ -57,6 +57,7 @@ Each constraint within a thought has specific tags that limit the thought to occ
 
 **ID:**
 Separates the thoughts into their blocks. Generally, the ID includes the condition, personality, age, and status of the main_cat, as well as the condition, personality, age, and status of any other cat mentioned.
+
 * paralyzed_gen_to_alive_gen
 * insecure_apprentice
 * general_formerclancat_dead_thoughts
@@ -79,6 +80,7 @@ Constrains the thought to only occur if a specific camp type is chosen (IE “ca
 
 **THOUGHTS:**
 This is where the text that will be displayed in-game is placed, current abbreviations that work are r_c (for random_cat) and c_n (for player clan name).
+
 * "Mewls pitifully for milk" (gen_dead_newborn)
 * "Wonders if {PRONOUN/m_c/subject} would have gotten the chance to do r_c's first check-up" (general_med_cat_app_to_dead_starclan_newborn1)
 * "Is wondering if r_c would have been {PRONOUN/m_c/poss} friend" (kit_dead_kit)
@@ -140,6 +142,7 @@ Constrains the thought if r_c has a specific place of death (first set of tags) 
 
 ## Examples and Notes
 Some general notes for thoughts:
+
 * Make sure everything is pronoun tagged before they go into a PR (if PR-ing to the official branch)
 * Try to keep the thoughts short, roughly around a 20-25 max word count
 * Do not include the name of the "thinker" (or the cat who is experiencing the thought)


### PR DESCRIPTION
The markdown formatter for mkdocs is very particular compared to the one used on GitHub Wiki, so there were some things that broke:
* Sublists require exactly four spaces for every level of indentation
* Lists and tables require an empty line prior to

Also:
* Added line breaks where they were seemingly intended
* Replaced straggling `#TODO` with TODO callout used everywhere else
* Made Getting Started with GitHub guide display properly as a list