### PR TITLE
Simple README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Clangen Docs
 This repository contains the documentation for Clangen.
 
+## Contributing
+
+Thank you for your interest in contributing to Clangen's documentation! To make a change in the documentation, you just have to change the corresponding `.md` file in the `/docs` folder. You can also create a new file in the folder and it will automatically create a new page in the documentation.
+
 ## Build Instructions
 
 ### Using pure Python

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Clangen Docs
+This repository contains the documentation for Clangen.
+
+## Build Instructions
+
+### Using pure Python
+
+1. Install dependencies:
+   ```
+   pip install .
+   ```
+2. Build documentation:
+   ```
+   python3 -m mkdocs build
+   ```
+3. The documentation will be in the `site` directory.
+   * Alternatively, you can run `python3 -m http.server -d site 8000` in order to access the documentation at http://localhost:8000.
+
+### Using uv
+
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
+2. Install dependencies:
+   ```
+   uv venv
+   uv pip install .
+   ```
+3. Build documentation:
+   ```
+   uv run mkdocs build
+   ```
+4. The documentation will be in the `site` directory.
+   * Alternatively, you can run `uv run python3 -m http.server -d site 8000` in order to access the documentation at http://localhost:8000.
+
+### Using Docker
+
+1. Install [Docker](https://www.docker.com).
+2. Build image:
+   ```
+   docker buildx build . -t clangen-docs
+   ```
+3. Run server:
+   ```
+   docker run -p 8000:80 clangen-docs
+   ```
+4. You can access the documentation at http://localhost:8000.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Thank you for your interest in contributing to Clangen's documentation! To make 
    ```
    pip install .
    ```
-2. Build documentation:
+2. Build and serve documentation:
    ```
-   python3 -m mkdocs build
+   python3 -m mkdocs serve
    ```
-3. The documentation will be in the `site` directory.
-   * Alternatively, you can run `python3 -m http.server -d site 8000` in order to access the documentation at http://localhost:8000.
+   Running this command will build the documentation and start a local server on your computer. While the server is running, you can access the documentation at http://localhost:8000. The site will update whenever the files in `/docs` are changed.
 
 ### Using uv
 
@@ -31,12 +30,11 @@ Thank you for your interest in contributing to Clangen's documentation! To make 
    uv venv
    uv pip install .
    ```
-3. Build documentation:
+3. Build and serve documentation:
    ```
-   uv run mkdocs build
+   uv run mkdocs serve
    ```
-4. The documentation will be in the `site` directory.
-   * Alternatively, you can run `uv run python3 -m http.server -d site 8000` in order to access the documentation at http://localhost:8000.
+   Running this command will build the documentation and start a local server on your computer. While the server is running, you can access the documentation at http://localhost:8000. The site will update whenever the files in `/docs` are changed.
 
 ### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Thank you for your interest in contributing to Clangen's documentation! To make 
 
 ## Build Instructions
 
+> [!IMPORTANT]
+> If you just want to contribute documentation, you don't **have** to do this. Building the documentation just creates a local copy of the documentation website on your computer, which can be useful for previewing your changes, but isn't necessarily required.
+
 ### Using pure Python
 
 1. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Thank you for your interest in contributing to Clangen's documentation! To make 
    ```
    docker run -p 8000:80 clangen-docs
    ```
-4. You can access the documentation at http://localhost:8000.
+4. You can access the documentation at http://localhost:8000. Unlike with uv and Python, this site will *not* update when the files in `/docs` are changed. To update the site, you have to close the server, then rebuild the image and run the server again.


### PR DESCRIPTION
Adds a simple README file with build instructions (for Python, uv, and Docker) and some basic information about contributing.

It’s a bit less hand-holdy than the regular documentation I previously wrote for Clangen, because I assumed that users contributing to this repository already have some basic knowledge of Python, forking, etc.